### PR TITLE
[WIP] Accept all input via params

### DIFF
--- a/CallFlowVisualizer.ps1
+++ b/CallFlowVisualizer.ps1
@@ -44,13 +44,16 @@ if (!$resourceAccount) {
         Out-GridView -PassThru -Title "Choose an Auto Attendant from the list to visualize your call flow:"
 }
 
-$aaProperties = New-Object -TypeName psobject
-
-$aaProperties | Add-Member -MemberType NoteProperty -Name "PhoneNumber" -Value $($resourceAccount.PhoneNumber).Replace("tel:","")
-
 $aa = Get-CsAutoAttendant | Where-Object {$_.ApplicationInstances -eq $resourceAccount.ObjectId}
+if (!$aa) {
+    Write-Error "$($resourceAccount.UserPrincipalName) is not assigned to an Auto Attendant"
+    return
+}
 
-$aaProperties | Add-Member -MemberType NoteProperty -Name "DisplayName" -Value $aa.Name
+$aaProperties = [PSCustomObject]@{
+    DisplayName = $aa.Name
+    PhoneNumber = $resourceAccount.PhoneNumber -Replace "^tel:",""
+}
 
 ####Check if AA has holidays
 if ($aa.CallHandlingAssociations.Type.Value -contains "Holiday") {

--- a/CallFlowVisualizer.ps1
+++ b/CallFlowVisualizer.ps1
@@ -33,10 +33,16 @@
 
 [CmdletBinding()]
 param(
+    [Parameter()]$resourceAccount = $null,
     [Parameter(Mandatory=$false)][ValidateSet("Markdown","Mermaid")][String]$docType = "Markdown"
 )
 
-$resourceAccount = Get-CsOnlineApplicationInstance | Where-Object {$_.PhoneNumber -notlike "" -and $_.ApplicationId -eq "ce933385-9390-45d1-9512-c8d228074e07"} | Select-Object DisplayName, PhoneNumber, ObjectId | Out-GridView -PassThru -Title "Choose an Auto Attendant from the list to visualize your call flow:"
+if (!$resourceAccount) {
+    $resourceAccount = Get-CsOnlineApplicationInstance | `
+        Where-Object {$_.PhoneNumber -notlike "" -and $_.ApplicationId -eq "ce933385-9390-45d1-9512-c8d228074e07"} | `
+        Select-Object DisplayName, PhoneNumber, ObjectId | `
+        Out-GridView -PassThru -Title "Choose an Auto Attendant from the list to visualize your call flow:"
+}
 
 $aaProperties = New-Object -TypeName psobject
 


### PR DESCRIPTION
Firstly, this is an exploration of ideas in the form of code changes so please do not actually merge this. It is intended for discussion only. If any of these sound good, I'm happy to work them into separate PRs.

Purpose: I'm working on adapting this to be able to create a web UI version. Ideally I would like to be able to reuse the entirely of the script but if that isn't possible then it would be nice to reuse as much of the logic as possible to allow for improvements to be synced.

Proposed Changes:

1. Adding param for the resource account/auto attendant/call queue to visualize. Apart from the fact that Out-GridView isn't supported on all platforms, this allows me to pull the desired object outside of the script and pass it in.
2. Adding params for all auto attendants/call queues. Similar to 1 above, namely being able to fetch it external to the script, I think using something like the GetAaForAppInstanceId or GetCqForAppInstanceId functions could speed up your script for deeply nested cases since it will pull them once instead of every time.
3. Refactor logic into functions. This is a bit of an example for how I think it might be possible to reduce the line count (CreateAfterHoursCheckNode is a good example) and simplify some of the logic (CreateHolidaySubgraph could actually be refactored again into a more generic CreateCallFlowSubgraph function) but also a bit of a plan B for me if 1 & 2 don't fit with your vision.

Questions/Outstanding Items:

1. Was there a reason that you weren't using functions or didn't want to have a generic CreateCallFlowSubgraph type function?
2. My API can't access the MsOnline api, which impacts the calls to Get-MsolUser and Get-MsolGroup. I was thinking I could replace the Get-MsolUser calls with Get-CsOnlineUser and then also pass them in as a param with a lookup function similar to Get{Aa,Cq}ForAppInstanceId (maybe GetUserForObjectId) but that doesn't cover the groups which I will need to still thinking about.
